### PR TITLE
Include topic in layer search issue 35

### DIFF
--- a/viewer/js/gis/dijit/LayerLoader.js
+++ b/viewer/js/gis/dijit/LayerLoader.js
@@ -798,6 +798,8 @@ function (declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, Dialog
                 encodedSearchTerms +
                 '+OR+description:' +
                 encodedSearchTerms +
+                '+OR+topic:' +
+                encodedSearchTerms +
                 ')';
             if (this.credentials.length === 0) {
                 searchUrl += '+AND+restricted:N';
@@ -807,7 +809,10 @@ function (declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, Dialog
                 var resultDocs = JSON.parse(reply).response.docs;
                 var searchResults = [];
                 resultDocs.forEach(function (doc) {
-                    if (doc.type === 'category') {
+                    //this business of checking if it's an array is because SOLR returns the type as an array. I don't think it should do that,
+                    //and perhaps we can fix it, so I've added a test to see if it's an array with value 'category' as a work-around,
+                    //and a test for simple string match if/when we do fix SOLR.
+                    if (doc.type && (Array.isArray(doc.type) && doc.type.indexOf('category') >= 0) || doc.type === 'category') {
                         var cat = self.allCategories.find(function (c) {
                             return ('c' + c.id) === doc.id;
                         });

--- a/viewer/js/gis/dijit/LayerLoader.js
+++ b/viewer/js/gis/dijit/LayerLoader.js
@@ -792,7 +792,9 @@ function (declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, Dialog
                 encodedSearchTerms +
                 '"^100+OR+description:"' +
                 encodedSearchTerms +
-                '"^50+OR+name:' +
+                '"^50+OR+topic:"' +
+                encodedSearchTerms +
+                '"^75+OR+name:' +
                 encodedSearchTerms +
                 '+OR+longName:' +
                 encodedSearchTerms +
@@ -800,7 +802,7 @@ function (declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, Dialog
                 encodedSearchTerms +
                 '+OR+topic:' +
                 encodedSearchTerms +
-                '^75)';
+                ')';
             if (this.credentials.length === 0) {
                 searchUrl += '+AND+restricted:N';
             }

--- a/viewer/js/gis/dijit/LayerLoader.js
+++ b/viewer/js/gis/dijit/LayerLoader.js
@@ -800,7 +800,7 @@ function (declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, Dialog
                 encodedSearchTerms +
                 '+OR+topic:' +
                 encodedSearchTerms +
-                ')';
+                '^75)';
             if (this.credentials.length === 0) {
                 searchUrl += '+AND+restricted:N';
             }


### PR DESCRIPTION
Adding search by topic to search string request passed to SOLR, and handling "category" response from search as an array or string. (SOLR was configured to return category as array, not a string; we may fix that, but the viewer can handle the response either way with this change.)