### PR TITLE
Load saved map extent enhancement (issue 38/Bug 5728)

### DIFF
--- a/viewer/js/gis/dijit/LayerLoader.js
+++ b/viewer/js/gis/dijit/LayerLoader.js
@@ -71,6 +71,9 @@ function (declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, Dialog
         //flags whether user wants to clear layers from the map before loading a new map
         clearMapFirst: ko.observable(false), // eslint-disable-line no-undef
 
+        //flags whether user wants to zoom to a saved map extent
+        zoomToSavedMapExtent: ko.observable(false), // eslint-disable-line no-undef
+
         //tracks whether changes have been made to the map
         hasUnsavedChanges: ko.observable(false), // eslint-disable-line no-undef
 
@@ -471,7 +474,7 @@ function (declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, Dialog
         loadSelectedMap: function () {
             if (this.selectedMap()) {
                 this.currentMap(this.selectedMap());
-                topic.publish('layerLoader/loadMap', this.selectedMap().id, this.clearMapFirst());
+                topic.publish('layerLoader/loadMap', this.selectedMap().id, this.clearMapFirst(), this.zoomToSavedMapExtent());
                 this.loadMapDialog.hide();
             }
         },

--- a/viewer/js/gis/dijit/LayerLoader/templates/layerLoaderSidebar.html
+++ b/viewer/js/gis/dijit/LayerLoader/templates/layerLoaderSidebar.html
@@ -45,7 +45,7 @@
         <!-- /ko -->
     </div>
 
-    <div data-dojo-type="dijit/Dialog" data-dojo-attach-point="loadMapDialog" title="Open Map" style="width: 300px; height: 200px" id="loadMapDialog">
+    <div data-dojo-type="dijit/Dialog" data-dojo-attach-point="loadMapDialog" title="Open Map" style="width: 300px; height: 235px" id="loadMapDialog">
         <label>Select Map</label>
         <input id="savedMapsDijit" type="select" data-dojo-type="dijit/form/FilteringSelect" data-dojo-props="name:'selectedMap',autoComplete:true,required:true,searchAttr:'mapName',labelAttr:'mapName',style:'width:100%;'" data-dojo-attach-point="savedMapsDijit" />
         <br />
@@ -54,6 +54,13 @@
             <label>
                 <input type="checkbox" data-dojo-attach-point="clearMapFirstCheckBox" data-dojo-type="dijit/form/CheckBox" data-dojo-props="'class':'optionsCheckBox'" data-bind="checked: clearMapFirst" />
                 Clear map before loading
+            </label>
+        </div>
+        <div data-dojo-attach-point="zoomToSavedMapExtentDom">
+            <br />
+            <label>
+                <input type="checkbox" data-dojo-attach-point="zoomToSavedMapExtentCheckBox" data-dojo-type="dijit/form/CheckBox" data-dojo-props="'class':'optionsCheckBox'" data-bind="checked: zoomToSavedMapExtent" />
+                Zoom to saved map extent
             </label>
         </div>
         <br />


### PR DESCRIPTION
<!-- Thank you for contributing to cmv! Contributions are welcome and are
absolutely necessary for the project to stay relevent and useful.
Please fill out the details to ensure others can understand the
changes you are proposing and how they will benefit the project. -->

# Description
Resolves Issue #38 (Bugzilla 5728)

# Use case
A user wants to load a saved map, but stay at their current map extent. Currently the extent is saved with the map and it will always zoom to the saved extent. This change allows users to choose whether to stay at the current extent or zoom to the saved extent.

# Checklist
<!-- please ensure your pull request passes the following check(s) -->

 - [X] Testing complete on Stage
 - [X] `grunt lint` produces no error messages
