### PR TITLE
Layer control default to expanded. Issue 48 / Bug 5784

### DIFF
--- a/viewer/js/gis/dijit/LayerControl/controls/templates/Folder.html
+++ b/viewer/js/gis/dijit/LayerControl/controls/templates/Folder.html
@@ -4,7 +4,7 @@
             <td class="layerControlTableExpand">
                 <i data-dojo-attach-point="expandIconNode" class="${icons.folder} layerControlIcon"></i>
             </td>
-            <td class="layerControlTableCheck">
+            <td class="layerControlTableCheck" title="Click to toggle visibility of this folder; if not checked, layers in this folder will not be shown, even if the layers in the folder are checked.">
                 <i data-dojo-attach-point="checkNode" class="${icons.unchecked} layerControlIcon"></i>
             </td>
             <td class="layerControlTableLabel">

--- a/viewer/js/viewer/_LayerLoadMixin.js
+++ b/viewer/js/viewer/_LayerLoadMixin.js
@@ -510,6 +510,7 @@ define([
                         noZoom: true, //we use our own zoom-to function, defined in menu below
                         mappkgDL: true,
                         allowRemove: true,
+                        expanded: true,
                         menu: [
                             {
                                 label: 'Open Attribute Table',

--- a/viewer/js/viewer/_LayerLoadMixin.js
+++ b/viewer/js/viewer/_LayerLoadMixin.js
@@ -502,7 +502,7 @@ define([
                 //todo: put this in config? Or have some default options if not in config?
                 var layerControlInfo = {
                     controlOptions: {
-                        expanded: false,
+                        expanded: true,
                         metadataUrl: false,
                         //includeUnspecifiedLayers: true, //TODO: if this is included, the service doesn't load properly for some reason, and no layers show up.
                         swipe: true,
@@ -510,7 +510,6 @@ define([
                         noZoom: true, //we use our own zoom-to function, defined in menu below
                         mappkgDL: true,
                         allowRemove: true,
-                        expanded: true,
                         menu: [
                             {
                                 label: 'Open Attribute Table',


### PR DESCRIPTION
 Minor configuration change to make map services appear in the layer control widget expanded by default. Also includes a tool tip for folder checkboxes to clarify behavior.
