### PR TITLE
Scalebar issue 59

### DIFF
--- a/viewer/css/app.css
+++ b/viewer/css/app.css
@@ -1,5 +1,6 @@
 @import url('./theme/flat/flat.css'); /* dojo's flat theme */
 @import url('./cmv.css'); /* the start of cmv theme */
+@import url('./scalebar.css'); /* override default scalebar styles */
 
 .appHeader {
     background-color: rgba(0, 116, 77, 255);

--- a/viewer/css/scalebar.css
+++ b/viewer/css/scalebar.css
@@ -31,7 +31,7 @@
 .esriScalebar {
     z-index: 30;
     position: absolute;
-    width: 0px;
+    width: 0;
     height: 20px;
 }
 
@@ -114,13 +114,11 @@
 }
 
 .esriScalebarLabel {
-    font-size: 11px;
     position: absolute;
     width: 10%;
     text-align: center;
-    color: black; /*was #666666; */
-    font: Verdana;
-    font-weight: bolder;
+    color: black; /* was #666666; */
+    font: bolder 11px Verdana;
     height: 5px;
     top: -1px;
 }
@@ -139,6 +137,9 @@
 }
 
 /* add halo */
-.esriScalebarLabel, .esriScalebarLineLabel, .esriScalebarSecondNumber, .esriScaleLabelDiv {
+.esriScalebarLabel,
+.esriScalebarLineLabel,
+.esriScalebarSecondNumber,
+.esriScaleLabelDiv {
     text-shadow: -1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, 1px 1px 0 #fff;
 }

--- a/viewer/css/scalebar.css
+++ b/viewer/css/scalebar.css
@@ -1,0 +1,144 @@
+﻿.scalebar_top-left {
+    left: 10px;
+    top: 10px;
+}
+
+.scalebar_top-center {
+    left: 50%;
+    top: 10px;
+}
+
+.scalebar_top-right {
+    right: 150px;
+    top: 10px;
+}
+
+.scalebar_bottom-left {
+    left: 25px;
+    bottom: 25px;
+}
+
+.scalebar_bottom-center {
+    left: 50%;
+    bottom: 25px;
+}
+
+.scalebar_bottom-right {
+    right: 100px;
+    bottom: 25px;
+}
+
+.esriScalebar {
+    z-index: 30;
+    position: absolute;
+    width: 0px;
+    height: 20px;
+}
+
+.esriScalebarRuler {
+    overflow: hidden;
+    position: relative;
+    width: 100%;
+    height: 6px;
+    background-color: White;
+    border: 1px solid black /* was #444444 */;
+}
+
+.esriScalebarRulerBlock {
+    overflow: hidden;
+    position: absolute;
+    height: 50%;
+    background-color: black /* was #444444 */;
+}
+
+.upper_firstpiece {
+    top: 0%;
+    left: 0%;
+    width: 25%;
+}
+
+.upper_secondpiece {
+    top: 0%;
+    left: 50%;
+    width: 25%;
+}
+
+.lower_firstpiece {
+    top: 50%;
+    left: 25%;
+    width: 25%;
+}
+
+.lower_secondpiece {
+    top: 50%;
+    left: 75%;
+    width: 30%;
+}
+
+.esriScalebarLine {
+    overflow: hidden;
+    position: relative;
+    width: 100%;
+    height: 6px;
+    border: 2px solid black; /* changed to black from border: 2px solid #444444; */
+    background-color: rgba(255, 255, 255, 0.5); /* added to simulate halo */
+}
+
+.esriScalebarMetricLineBackground {
+    border: 4px solid white;
+    position: absolute;
+    left: -1px;
+    bottom: 2px;
+}
+
+.esriScalebarMetricLine {
+    border-top-style: none;
+}
+
+.esriScalebarEnglishLine {
+    border-bottom-style: none;
+    top: -2px;
+}
+
+.esriScaleLabelDiv {
+    position: relative;
+    top: -5px;
+    width: 100%;
+    padding: 2px;
+}
+
+.scaleLabelDiv {
+    position: relative;
+    width: 100%;
+    height: 5px;
+}
+
+.esriScalebarLabel {
+    font-size: 11px;
+    position: absolute;
+    width: 10%;
+    text-align: center;
+    color: black; /*was #666666; */
+    font: Verdana;
+    font-weight: bolder;
+    height: 5px;
+    top: -1px;
+}
+
+.esriScalebarLineLabel {
+    position: relative;
+}
+
+.esriScalebarFirstNumber {
+    left: 45%;
+}
+
+.esriScalebarSecondNumber {
+    left: 95%;
+    white-space: nowrap;
+}
+
+/* add halo */
+.esriScalebarLabel, .esriScalebarLineLabel, .esriScalebarSecondNumber, .esriScaleLabelDiv {
+    text-shadow: -1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, 1px 1px 0 #fff;
+}

--- a/viewer/css/scalebar.css
+++ b/viewer/css/scalebar.css
@@ -31,7 +31,7 @@
 .esriScalebar {
     z-index: 30;
     position: absolute;
-    width: 0px;
+    width: 0;
     height: 20px;
 }
 
@@ -114,13 +114,11 @@
 }
 
 .esriScalebarLabel {
-    font-size: 11px;
     position: absolute;
     width: 10%;
     text-align: center;
-    color: black; /*was #666666; */
-    font: Verdana;
-    font-weight: bolder;
+    color: black; /*was #666666;*/
+    font: bolder 11px Verdana;
     height: 5px;
     top: -1px;
 }
@@ -139,6 +137,9 @@
 }
 
 /* add halo */
-.esriScalebarLabel, .esriScalebarLineLabel, .esriScalebarSecondNumber, .esriScaleLabelDiv {
+.esriScalebarLabel, 
+.esriScalebarLineLabel, 
+.esriScalebarSecondNumber, 
+.esriScaleLabelDiv {
     text-shadow: -1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, 1px 1px 0 #fff;
 }


### PR DESCRIPTION
<!-- Thank you for contributing to cmv! Contributions are welcome and are
absolutely necessary for the project to stay relevent and useful.
Please fill out the details to ensure others can understand the
changes you are proposing and how they will benefit the project. -->

# Description

Resolves #59. When aerial basemap is selected, scalebar styling makes it hard to see. Currently set to color #444444 (a medium-dark gray). This set of changes sets the text and scalebar lines to black, adds a white halo around text, and adds a semi-transparent (50%) background to the scalebars.

# Checklist
<!-- please ensure your pull request passes the following check(s) -->

 - [X] `grunt lint` produces no error messages
 - [X] Testing complete
