### PR TITLE
Updating link from AOI editor to new version of GIS report

### DIFF
--- a/viewer/js/gis/dijit/AoiEditor.js
+++ b/viewer/js/gis/dijit/AoiEditor.js
@@ -563,7 +563,7 @@ function (declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin,
                             text: p.progressGIS.text,
                             running: p.progressGIS.running,
                             title: 'Study Area Report',
-                            href: '/est/analysis/ReportOptions.do?aoiId=' + self.aoiId()
+                            href: '/est/analysis/secure/ReportOptions.do?aoiId=' + self.aoiId()
                         },
                         hcm = {
                             code: p.progressHCM.code,

--- a/viewer/js/gis/dijit/AoiEditor.js
+++ b/viewer/js/gis/dijit/AoiEditor.js
@@ -563,7 +563,7 @@ function (declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin,
                             text: p.progressGIS.text,
                             running: p.progressGIS.running,
                             title: 'Study Area Report',
-                            href: '/est/analysis/secure/ReportOptions.do?aoiId=' + self.aoiId()
+                            href: '/est/secure/analysis/ReportOptions.do?aoiId=' + self.aoiId()
                         },
                         hcm = {
                             code: p.progressHCM.code,


### PR DESCRIPTION
Follow up to previous pull request for map integration with new GIS report, this changes the outbound link from the AOI editor to the GIS report to /est/secure/analysis/ReportOptions.do. 