### PR TITLE
Bug 5864 / #65 (Layer name in legend)

### DIFF
--- a/viewer/js/viewer/_LayerLoadMixin.js
+++ b/viewer/js/viewer/_LayerLoadMixin.js
@@ -608,7 +608,9 @@ define([
                 }
 
                 //fix for issue #65; arcgisProps.title is used for feature layer title in printed TOC
-                layer.arcgisProps = { title: layerDef.name};
+                layer.arcgisProps = {
+                    title: layerDef.name
+                };
 
                 var layerControlInfo = { //Note this is actually a "LayerInfo", a property passed into the layerInfos property of the LayerControl class
                     controlOptions: {

--- a/viewer/js/viewer/_LayerLoadMixin.js
+++ b/viewer/js/viewer/_LayerLoadMixin.js
@@ -607,7 +607,10 @@ define([
                     }
                 }
 
-                var layerControlInfo = {
+                //fix for issue #65; arcgisProps.title is used for feature layer title in printed TOC
+                layer.arcgisProps = { title: layerDef.name};
+
+                var layerControlInfo = { //Note this is actually a "LayerInfo", a property passed into the layerInfos property of the LayerControl class
                     controlOptions: {
                         expanded: true,
                         metadataUrl: false,


### PR DESCRIPTION
# Description

Resolve #65 / [Bug 5864 ](https://repo.fla-etat.org/bugzilla/show_bug.cgi?id=5864)- Reflect the Layer Name for features instead of the Layer ID in the legend for printed maps 

